### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,8 @@
 # documentation.
 
 name: Publish Docker image
+permissions:
+  contents: read
 
 on:
   release:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/FSU-ACM/Programming-Contest-Suite/security/code-scanning/1](https://github.com/FSU-ACM/Programming-Contest-Suite/security/code-scanning/1)

The recommended fix is to add a `permissions` block at the root level (top of the workflow YAML), directly after the `name:`, setting `contents: read`. This will limit the GITHUB_TOKEN to only allow reading the repository contents, which is sufficient for the steps shown (checkout, setup Python, install dependencies, run Pylint). This change is minimal, non-breaking, and adoptable on almost any workflow like this.

**File/lines to change:**  
- Edit `.github/workflows/pylint.yml`  
- Add, after the `name: Pylint` header and before the `on:` key, the following lines:
  ```yaml
  permissions:
    contents: read
  ```
No other imports, method changes, or modifications are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
