### PR TITLE
Update Pylint workflow

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,20 +2,33 @@ name: Pylint
 permissions:
   contents: read
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+      - dev
+    paths:
+      - '**.py'
+  pull_request:
+    branches:
+      - main
+      - dev
+    paths:
+      - '**.py'
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Closes #59

## Summary
- Update checkout and setup-python actions
- Add pip caching
- Restrict runs to Python file changes on main/dev pushes and pull requests
- Rename the workflow job from build to lint